### PR TITLE
完善统计模块细节

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -15,14 +15,15 @@ const routes: Array<RouteRecordRaw> = [
     name: 'Publicity',
     component: () => import('../views/Publicity.vue')
   },
-  {
-    path: '/team',
-    name: 'Team',
-    component: () => import('../views/Team.vue')
-  },
+  // {
+  //   path: '/team',
+  //   name: 'Team',
+  //   component: () => impor../views/PersonDetail.vuevue')
+  // },
   {
     path: '/statistics',
     name: 'Statistics',
+    redirect: '/statistics/date-arrange',
     children: [
       {
         path: 'solve-problems',
@@ -39,6 +40,11 @@ const routes: Array<RouteRecordRaw> = [
       {
         path: 'person-data',
         component: () => import('../views/Statistics/PersonData.vue')
+      },
+      {
+        name: 'person-detial',
+        path: 'person-data/:id',
+        component: () => import('../views/Statistics/PersonDetail.vue')
       }
     ],
     component: () => import('../views/Statistics.vue')

--- a/src/views/Statistics/DateArrange.vue
+++ b/src/views/Statistics/DateArrange.vue
@@ -1,152 +1,272 @@
 <template>
     <el-container>
-        <el-main style="position:fixed;left:230px;top:60px;height:600px">
-            <el-tabs v-model="activeName" @tab-click="handleClick">
-                <el-tab-pane label="日程安排" name="first">
-                    <el-calendar>
-                        <template #dateCell="{data}">
-                            <p :span="24" class="data.isSelected ? 'is-selected' : ''">
-                                {{ data.day.split('-').slice(1).join('.') }} {{ data.isSelected ? '✔️' : '' }}
-                            </p>
-                        </template>
-                    </el-calendar>
-                </el-tab-pane>
-                <el-tab-pane label="添加事件" name="second">
+        <el-main style="position:fixed;left:250px;top:80px;height:600px">
+            <el-button type="primary" @click="dialog = true">添加事件</el-button>
+            <el-drawer title="添加事件" :before-close="handleClose" v-model="dialog" direction="rtl"
+                custom-class="demo-drawer" ref="drawer" style="width:40%">
+                <div class="demo-drawer__content">
+                    <el-form ref="form" :model="form" label-width="80px">
 
-                    <el-form :model="ruleForm" :rules="rules" ref="ruleForm" label-width="100px" class="demo-ruleForm">
-                        <el-form-item label="活动名称" prop="name">
-                            <el-input v-model="ruleForm.name"></el-input>
+                        <el-form-item label="活动名称">
+                            <el-input v-model="form.name"></el-input>
                         </el-form-item>
-                        <el-form-item label="活动类型" prop="region">
-                            <el-select v-model="ruleForm.region" placeholder="请选择活动类型">
-                                <el-option label="正式赛" value="contest"></el-option>
+                        <el-form-item label="活动性质">
+                            <el-select v-model="form.region" placeholder="请选择活动性质">
                                 <el-option label="训练赛" value="train"></el-option>
-                                <el-option label="专题授课" value="leason"></el-option>
+                                <el-option label="正式赛" value="contest"></el-option>
+                                <el-option label="专题讲课" value="lesson"></el-option>
                             </el-select>
                         </el-form-item>
-                        <el-form-item label="活动时间" required>
+                        <el-form-item label="活动时间">
                             <el-col :span="11">
-                                <el-form-item prop="date1">
-                                    <el-date-picker type="date" placeholder="选择日期" v-model="ruleForm.date1"
-                                        style="width: 100%;" :shortcuts="shortcuts"></el-date-picker>
-                                </el-form-item>
+                                <el-date-picker type="date" placeholder="选择日期" v-model="form.date1"
+                                    style="width: 100%;"></el-date-picker>
                             </el-col>
                             <el-col class="line" :span="2">-</el-col>
                             <el-col :span="11">
-                                <el-form-item prop="date2">
-                                    <el-time-picker placeholder="选择时间" v-model="ruleForm.date2" style="width: 100%;">
-                                    </el-time-picker>
-                                </el-form-item>
+                                <el-time-picker placeholder="选择时间" v-model="form.date2" style="width: 100%;">
+                                </el-time-picker>
                             </el-col>
                         </el-form-item>
-                        <el-form-item>
-                            <el-button type="primary" @click="submitForm('ruleForm')">立即创建</el-button>
-                            <el-button @click="resetForm('ruleForm')">重置</el-button>
-                        </el-form-item>
+
                     </el-form>
+                    <div class="demo-drawer__footer">
+                        <el-button @click="cancelForm">取 消</el-button>
+                        <el-button type="primary" @click="$refs.drawer.closeDrawer()" :loading="loading">
+                            {{ loading ? '提交中 ...' : '确 定' }}</el-button>
+                    </div>
+                </div>
+            </el-drawer>
+            <!-- echart日历 暂时不能显示 -->
+            <v-chart class="chart" :option="option" />
 
-
-                </el-tab-pane>
-            </el-tabs>
         </el-main>
     </el-container>
 </template>
 
-<style>
-    .is-selected {
-        color: #1989FA;
+<style scoped>
+    .demo-drawer__footer {
+        position: relative;
+        left: 230px;
+        top: 10px;
+    }
+
+    .demo-drawer__content {
+        max-width: 380px;
+        left: 10px;
+    }
+
+    .chart {
+        height: 450px;
+        width: 800px;
+        position: absolute;
+        left: 25%;
+        top: 20%
     }
 </style>
 
-<script>
-    export default {
+<script lang="js">
+    import * as echarts from 'echarts/core';
+    import {
+        CalendarComponent,
+        TooltipComponent
+    } from 'echarts/components';
+    import {
+        CustomChart
+    } from 'echarts/charts';
+    import {
+        CanvasRenderer
+    } from 'echarts/renderers';
+    import {
+        ref,
+        defineComponent
+    } from "vue";
+    echarts.use(
+        [CalendarComponent, TooltipComponent, CustomChart, CanvasRenderer]
+    );
+
+    export default defineComponent({
+        ///以下为echart日历
+        setup: () => {
+            var layouts = [
+                [
+                    [0, 0]
+                ],
+                [
+                    [-0.25, 0],
+                    [0.25, 0]
+                ],
+                [
+                    [0, -0.2],
+                    [-0.2, 0.2],
+                    [0.2, 0.2]
+                ],
+                [
+                    [-0.25, -0.25],
+                    [-0.25, 0.25],
+                    [0.25, -0.25],
+                    [0.25, 0.25]
+                ]
+            ];
+            var pathes = [
+                'M936.857805 523.431322c0 0-42.065715-68.89513-88.786739-68.89513-46.68416 0-95.732122 71.223091-95.732122 71.223091s-44.28544-72.503296-93.440922-71.152538c-35.565466 0.977306-62.89705 30.882406-79.124275 64.06615L579.773747 790.800797c-3.253248 37.391565-5.677568 50.904371-12.002816 69.63497-6.651802 19.698688-19.544883 35.227341-31.650099 45.909606-14.30231 12.621414-29.59831 22.066586-45.854208 27.424563-16.28969 5.362074-30.098739 6.496973-51.536794 6.496973-19.498906 0-36.95104-2.963456-52.395418-8.850534-15.410586-5.887078-28.420403-14.313984-39.034573-25.246003-10.613146-10.930995-18.757939-24.08151-24.435507-39.525171-5.676544-15.443763-8.532685-40.195482-8.532685-59.270963l0-26.232454 74.435273 0c0 24.644301-0.17705 64.452915 8.81408 77.006848 9.02697 12.515021 22.756147 18.092032 41.148826 18.791014 16.728678 0.636518 30.032179-8.061645 30.032179-8.061645s11.922022-10.5472 14.992077-19.756954c2.674995-8.025805 3.565363-22.180147 3.565363-22.180147s2.080461-21.789286 2.080461-34.234675L489.399906 514.299369c-16.678502-18.827776-43.801395-61.938688-82.756096-60.927693-54.699008 1.419366-100.422144 70.059622-100.422144 70.059622s-56.065126-70.059622-93.440922-70.059622c-37.376717 0-91.077939 70.059622-91.077939 70.059622S105.343488 156.737741 476.742042 119.363584l53.70327-74.714624 51.373056 74.714624C964.889395 142.740992 936.857805 523.431322 936.857805 523.431322z',
+                'M533.504 268.288q33.792-41.984 71.68-75.776 32.768-27.648 74.24-50.176t86.528-19.456q63.488 5.12 105.984 30.208t67.584 63.488 34.304 87.04 6.144 99.84-17.92 97.792-36.864 87.04-48.64 74.752-53.248 61.952q-40.96 41.984-85.504 78.336t-84.992 62.464-73.728 41.472-51.712 15.36q-20.48 1.024-52.224-14.336t-69.632-41.472-79.872-61.952-82.944-75.776q-26.624-25.6-57.344-59.392t-57.856-74.24-46.592-87.552-21.504-100.352 11.264-99.84 39.936-83.456 65.536-61.952 88.064-35.328q24.576-5.12 49.152-1.536t48.128 12.288 45.056 22.016 40.96 27.648q45.056 33.792 86.016 80.896z',
+                'M741.06368 733.310464c8.075264-29.262438 20.615373-40.632422 14.64105-162.810061C966.089728 361.789952 967.93897 72.37847 967.855002 54.693683c0.279347-0.279347 0.418509-0.419533 0.418509-0.419533s-0.17705-0.00512-0.428749-0.00512c0-0.251699 0-0.428749 0-0.428749s-0.139162 0.14633-0.418509 0.425677c-17.695744-0.083866-307.10784 1.760051-515.833958 212.142592-122.181632-5.984256-133.55305 6.563533-162.815693 14.644531C235.35063 295.798886 103.552614 436.975309 90.630758 486.076621c-12.921856 49.105408 39.634227 56.859034 58.579558 58.581197 18.953421 1.724314 121.471386-9.475789 130.09111 4.309094 0 0 16.367411 11.200102 17.226035 41.346662 0.850432 29.796659 15.173222 71.354163 37.123994 97.267302-0.028672 0.027648-0.05632 0.054272-0.083866 0.074752 0.158618 0.13097 0.316211 0.261939 0.474829 0.390861 0.129946 0.149402 0.261939 0.319283 0.393011 0.468685 0.019456-0.019456 0.04608-0.049152 0.075776-0.075674 25.918362 21.961216 67.477504 36.272128 97.269248 37.122458 30.149837 0.859546 41.354547 17.234534 41.354547 17.234534 13.779354 8.608051 2.583962 111.122842 4.302131 130.075546 1.727386 18.95168 9.477222 71.498445 58.579558 58.576077C585.12896 918.526771 726.311117 786.734182 741.06368 733.310464zM595.893555 426.206003c-39.961702-39.965184-39.961702-104.75991 0-144.720077 39.970918-39.96928 104.768307-39.96928 144.730112 0 39.970918 39.960064 39.970918 104.75479 0 144.720077C700.661862 466.171187 635.864474 466.171187 595.893555 426.206003zM358.53312 769.516032c-31.923302-4.573184-54.890394-18.410291-71.41847-35.402342-16.984474-16.526438-30.830387-39.495475-35.405824-71.420621-4.649062-28.082586-20.856832-41.167565-38.76649-38.763827-17.906586 2.40681-77.046886 66.714419-80.857805 89.475891-3.80887 22.752154 29.271859 12.081152 46.424166 27.654861 17.151283 15.590093-2.139853 61.93664-14.733107 86.845952-6.441984 12.735078-10.289766 26.42176-4.22953 33.76087 7.346586 6.070272 21.03593 2.222592 33.769472-4.220109 24.912384-12.585677 71.258829-31.872922 86.842368-14.731469 15.583539 17.160806 4.911002 50.229965 27.674419 46.419251 22.754099-3.807744 87.065395-62.946611 89.466163-80.85248C399.70857 790.374093 386.627072 774.166938 358.53312 769.516032z',
+                'M848.794624 939.156685 571.780416 939.156685 571.780416 653.17123l341.897539 0 0 221.100654C913.677926 909.960704 884.482867 939.156685 848.794624 939.156685zM571.780403 318.743552c-11.861606-3.210138-31.443354-8.36864-39.829709-16.176435-0.596582-0.561766-1.016218-1.246413-1.613824-1.841971-0.560845 0.596582-1.016218 1.280205-1.613824 1.841971-8.386355 7.807795-15.96631 12.965274-27.827917 16.176435l0 263.544325L141.030675 582.287877 141.030675 355.202884c0-35.687834 29.195059-64.882688 64.883302-64.882688l150.649125 0c-16.984474-9.525965-32.846438-20.56233-46.111027-32.932045-60.250624-56.144691-71.129907-137.062605-24.283034-180.767027 19.615539-18.264986 46.252237-27.124736 75.026739-27.124736 39.933133 0 83.972915 17.070797 118.995968 49.706086 20.353331 18.983322 37.722624 43.405619 50.145075 69.056819 12.457267-25.6512 29.791744-50.074419 50.180915-69.056819 35.022029-32.63529 79.062835-49.706086 118.994944-49.706086 28.74071 0 55.410176 8.860774 75.025715 27.124736 46.882611 43.704422 35.96759 124.622336-24.283034 180.767027-13.264589 12.368691-29.127578 23.40608-46.111027 32.932045l144.649234 0c35.688243 0 64.882278 29.195981 64.882278 64.882688l0 227.084948L571.780416 582.287833 571.780416 318.743508zM435.064218 147.625267c-21.476966-19.965747-49.094144-31.913882-73.868288-31.913882-7.404954 0-21.125018 1.211597-29.863322 9.386803-2.000691 1.824563-8.070144 7.439462-8.070144 21.369754 0 15.650406 8.492749 40.24873 32.319386 62.477926 29.124506 27.12576 77.202432 47.601152 111.76704 47.601152 12.176794 0 16.492237-2.666701 16.527053-2.702541C489.524736 242.54505 475.664486 185.453773 435.064218 147.625267zM577.78135 254.790963c0 0 0.034816-0.034816 0.069632-0.034816 0.807424 0 5.50871 1.790771 15.509914 1.790771 34.564608 0 82.64151-20.47529 111.76704-47.601152 23.826637-22.229299 32.283546-46.810112 32.283546-62.442189 0-13.930291-6.033613-19.562496-8.035328-21.404467-8.77312-8.17623-22.457344-9.386803-29.864346-9.386803-24.808038 0-52.390298 11.948134-73.867264 31.913882C585.325466 185.208218 571.358822 241.73865 577.78135 254.790963zM500.89513 939.156685 205.914017 939.156685c-35.688243 0-64.883302-29.195981-64.883302-64.883712L141.030714 653.17123l359.864462 0L500.895177 939.15666z'
+            ];
+            var colors = [
+                '#c4332b', '#16B644', '#6862FD', '#FDC763'
+            ];
+
+            function getVirtulData(year) {
+                year = year || '2017';
+                var date = +echarts.number.parseDate(year + '-01-01');
+                var end = +echarts.number.parseDate((+year + 1) + '-01-01');
+                var dayTime = 3600 * 24 * 1000;
+                var data = [];
+                for (var time = date; time < end; time += dayTime) {
+                    var items = [];
+                    var eventCount = Math.round(Math.random() * pathes.length);
+                    for (var i = 0; i < eventCount; i++) {
+                        items.push(Math.round(Math.random() * (pathes.length - 1)));
+                    }
+                    data.push([
+                        echarts.format.formatTime('yyyy-MM-dd', time),
+                        items.join('|')
+                    ]);
+                }
+                return data;
+            }
+
+            function renderItem(params, api) {
+                var cellPoint = api.coord(api.value(0));
+                var cellWidth = params.coordSys.cellWidth;
+                var cellHeight = params.coordSys.cellHeight;
+
+                var value = api.value(1);
+                var events = value && value.split('|');
+
+                if (isNaN(cellPoint[0]) || isNaN(cellPoint[1])) {
+                    return;
+                }
+
+                var group = {
+                    type: 'group',
+                    children: (layouts[events.length - 1] || []).map(function (itemLayout, index) {
+                        return {
+                            type: 'path',
+                            shape: {
+                                pathData: pathes[events[index]],
+                                x: -8,
+                                y: -8,
+                                width: 16,
+                                height: 16
+                            },
+                            position: [
+                                cellPoint[0] + echarts.number.linearMap(itemLayout[0], [-
+                                    0.5, 0.5
+                                ], [-cellWidth / 2, cellWidth / 2]),
+                                cellPoint[1] + echarts.number.linearMap(itemLayout[1], [-
+                                    0.5, 0.5
+                                ], [-cellHeight / 2 + 20, cellHeight / 2])
+                            ],
+                            style: api.style({
+                                fill: colors[events[index]]
+                            })
+                        };
+                    }) || []
+                }
+
+                group.children.push({
+                    type: 'text',
+                    style: {
+                        x: cellPoint[0],
+                        y: cellPoint[1] - cellHeight / 2 + 15,
+                        text: echarts.format.formatTime('dd', api.value(0)),
+                        fill: '#777',
+                        textFont: api.font({
+                            fontSize: 14
+                        })
+                    }
+                });
+
+                return group;
+            }
+
+            const option = ref({
+                tooltip: {},
+                calendar: [{
+                    left: 'center',
+                    top: 'middle',
+                    cellSize: [70, 70],
+                    yearLabel: {
+                        show: true
+                    },
+                    orient: 'vertical',
+                    dayLabel: {
+                        firstDay: 1,
+                        nameMap: 'cn'
+                    },
+                    monthLabel: {
+                        show: true
+                    },
+                    range: '2017-03'
+                }],
+                series: [{
+                    type: 'custom',
+                    coordinateSystem: 'calendar',
+                    renderItem: renderItem,
+                    dimensions: [null, {
+                        type: 'ordinal'
+                    }],
+                    data: getVirtulData(2017)
+                }]
+
+            });
+
+            return {
+                option
+            };
+        },
+        ///以上为echart日历
         data() {
             return {
-                activeName: 'second',
-                disabledDate(time) {
-                    return time.getTime() > Date.now()
-                },
-                shortcuts: [{
-                    text: 'Today',
-                    value: new Date(),
-                }, {
-                    text: 'Tomorrow',
-                    value: (() => {
-                        const date = new Date()
-                        date.setTime(date.getTime() + 3600 * 1000 * 24)
-                        return date
-                    })(),
-                }, {
-                    text: 'A week Later',
-                    value: (() => {
-                        const date = new Date()
-                        date.setTime(date.getTime() + 3600 * 1000 * 24 * 7)
-                        return date
-                    })(),
-                }],
-                value1: '',
-                value2: '',
-
-                ruleForm: {
+                table: false,
+                dialog: false,
+                loading: false,
+                form: {
                     name: '',
                     region: '',
                     date1: '',
                     date2: '',
-                    delivery: false,
-                    type: [],
-                    resource: '',
-                    desc: ''
                 },
-                rules: {
-                    name: [{
-                            required: true,
-                            message: '请输入活动名称',
-                            trigger: 'blur'
-                        },
-                        {
-                            min: 0,
-                            max: 20,
-                            message: '长度在 0 到 20 个字符',
-                            trigger: 'blur'
-                        }
-                    ],
-                    region: [{
-                        required: true,
-                        message: '请选择活动类型',
-                        trigger: 'change'
-                    }],
-                    date1: [{
-                        type: 'date',
-                        required: true,
-                        message: '请选择日期',
-                        trigger: 'change'
-                    }],
-                    date2: [{
-                        type: 'date',
-                        required: true,
-                        message: '请选择时间',
-                        trigger: 'change'
-                    }],
-                }
-            };
+                formLabelWidth: '80px',
+                timer: null,
+            }
         },
         methods: {
-            handleClick(tab, event) {
-                console.log(tab, event);
+            handleClose(done) {
+                if (this.loading) {
+                    return;
+                }
+                this.$confirm('确定要提交信息吗？')
+                    .then(_ => {
+                        this.loading = true;
+                        this.timer = setTimeout(() => {
+                            done();
+                            // 动画关闭需要一定的时间
+                            setTimeout(() => {
+                                this.loading = false;
+                            }, 400);
+                        }, 2000);
+                    })
+                // .catch(_ => {});
             },
-            submitForm(formName) {
-                this.$refs[formName].validate((valid) => {
-                    if (valid) {
-                        alert('submit!');
-                    } else {
-                        console.log('error submit!!');
-                        return false;
-                    }
-                });
-            },
-            resetForm(formName) {
-                this.$refs[formName].resetFields();
+            cancelForm() {
+                this.loading = false;
+                this.dialog = false;
+                clearTimeout(this.timer);
             }
         }
-    }
+    })
 </script>

--- a/src/views/Statistics/PersonData.vue
+++ b/src/views/Statistics/PersonData.vue
@@ -1,7 +1,7 @@
 <template>
     <el-container>
         <el-main>
-            <el-row :span="6">
+            <el-row :span="6" v-for="(x, index) in 3" :key="x" :offset="index > 0 ? 2 : 0">
                 <el-col :span="6" v-for="(o, index) in 3" :key="o" :offset="index > 0 ? 2 : 0">
                     <el-card :body-style="{ padding: '0px' }" shadow="hover">
                         <img src="https://shadow.elemecdn.com/app/element/hamburger.9cf7b091-55e9-11e9-a976-7f4d0b07eef6.png"
@@ -9,40 +9,11 @@
                         <div style="padding: 10px;">
                             <span>Name</span>
                             <div class="bottom">
-                                <b><el-button type="text" class="button">详细信息</el-button></b>
+                                <router-link to="person-data/1"><el-button type="text" class="button">详细信息</el-button></router-link>
                             </div>
                         </div>
                     </el-card>
-                </el-col>
-            </el-row>
-            <br/><br/>
-            <el-row :span="6">
-                <el-col :span="6" v-for="(o, index) in 3" :key="o" :offset="index > 0 ? 2 : 0">
-                    <el-card :body-style="{ padding: '0px' }" shadow="hover">
-                        <img src="https://shadow.elemecdn.com/app/element/hamburger.9cf7b091-55e9-11e9-a976-7f4d0b07eef6.png"
-                            class="image">
-                        <div style="padding: 10px;">
-                            <span>Name</span>
-                            <div class="bottom">
-                                <b><el-button type="text" class="button">详细信息</el-button></b>
-                            </div>
-                        </div>
-                    </el-card>
-                </el-col>
-            </el-row>
-            <br/><br/>
-            <el-row :span="6">
-                <el-col :span="6" v-for="(o, index) in 3" :key="o" :offset="index > 0 ? 2 : 0">
-                    <el-card :body-style="{ padding: '0px' }" shadow="hover">
-                        <img src="https://shadow.elemecdn.com/app/element/hamburger.9cf7b091-55e9-11e9-a976-7f4d0b07eef6.png"
-                            class="image">
-                        <div style="padding: 10px;">
-                            <span>Name</span>
-                            <div class="bottom">
-                                <b><el-button type="text" class="button">详细信息</el-button></b>
-                            </div>
-                        </div>
-                    </el-card>
+                    <br/><br/>
                 </el-col>
             </el-row>
         </el-main>
@@ -77,15 +48,6 @@
   }
 </style>
 
-<script>
-    export default {
-        data() {
-            return {
-                currentDate: new Date(),
-                circleUrl: "https://cube.elemecdn.com/3/7c/3ea6beec64369c2642b92c6726f1epng.png",
-                squareUrl: "https://cube.elemecdn.com/9/c2/f0ee8a3c7c9638a54940382568c9dpng.png",
-                sizeList: ["large", "medium", "small"]
-            };
-        }
-    }
+<script scope>
+
 </script>

--- a/src/views/Statistics/PersonDetail.vue
+++ b/src/views/Statistics/PersonDetail.vue
@@ -1,0 +1,24 @@
+<template>
+  <router-link to="../person-data">
+    <el-button type="botton" class="button">返回</el-button>
+  </router-link>
+</template>
+
+<style scoped>
+  .button {
+    font-size: 15px;
+    position: absolute;
+    left: 90%;
+    top: 15%
+  }
+</style>
+
+<script>
+  export default {
+    methods: {
+      goBack() {
+        console.log('go back');
+      }
+    }
+  }
+</script>

--- a/src/views/Statistics/Rating.vue
+++ b/src/views/Statistics/Rating.vue
@@ -107,6 +107,10 @@
 
 <style scoped>
     .chart {
-        height: 400px;
+        height: 450px;
+        width: 800px;
+        position: absolute;
+        left: 25%;
+        top: 20%
     }
 </style>

--- a/src/views/Statistics/SolveProblems.vue
+++ b/src/views/Statistics/SolveProblems.vue
@@ -107,6 +107,10 @@
 
 <style scoped>
     .chart {
-        height: 400px;
+        height: 450px;
+        width: 800px;
+        position: absolute;
+        left: 25%;
+        top: 20%
     }
 </style>

--- a/src/views/Team.vue
+++ b/src/views/Team.vue
@@ -1,3 +1,0 @@
-<template>
-  组队信息
-</template>


### PR DESCRIPTION
重定向 统计路由 ->训练日程
增加 队员信息动态路由分配
*(循环写法的id值还不会改)
*(添加PersonDetail.vue作为个人页面模块)
*(删除组队模块)
替换日程安排的日历
*(想用echart的日历还未实现)
将 添加事件 变为 抽屉 效果
对Rating以及刷题数 的表位置进行调整
